### PR TITLE
Color for Linux version

### DIFF
--- a/Termi-Linux/main.cpp
+++ b/Termi-Linux/main.cpp
@@ -25,8 +25,6 @@ int main()
     cout << "          (c)2021 ringwormGO all rights reserved" << endl;
     cout << "-------------------------------------------------------  " << endl;
 
-    system("color 1E");
-
     // command loop
     while (1)
     {
@@ -263,10 +261,6 @@ int main()
 
 
                 }
-
-
-
-
             }
         }
     }


### PR DESCRIPTION
Remove ```system("color 1E")``` beacuse Linux don't have color command and Termi don't use ```system``` command.

This pull request is also created for further ideas and fixes for colors in Linux version