### PR TITLE
Update base64.hpp

### DIFF
--- a/src/Termi-Commands/Commands/base64.hpp
+++ b/src/Termi-Commands/Commands/base64.hpp
@@ -10,20 +10,22 @@
 #include <iostream>
 #include <vector>
 
+// Base64 character set, plus padding character (=)
+static const std::string BASE64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
 static std::string base64_encode(const std::string &in) 
 {
     std::string out;
-
     int val = 0, valb = -6;
     for (unsigned char c : in) {
         val = (val << 8) + c;
         valb += 8;
         while (valb >= 0) {
-            out.push_back("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"[(val>>valb)&0x3F]);
+            out.push_back(BASE64_CHARS[(val>>valb)&0x3F]);
             valb -= 6;
         }
     }
-    if (valb>-6) out.push_back("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"[((val<<8)>>(valb+8))&0x3F]);
+    if (valb>-6) out.push_back(BASE64_CHARS[((val<<8)>>(valb+8))&0x3F]);
     while (out.size()%4) out.push_back('=');
     return out;
 }
@@ -31,9 +33,8 @@ static std::string base64_encode(const std::string &in)
 static std::string base64_decode(const std::string &in) 
 {
     std::string out;
-
     std::vector<int> T(256,-1);
-    for (int i=0; i<64; i++) T["ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"[i]] = i;
+    for (int i=0; i<64; i++) T[BASE64_CHARS[i]] = i;
 
     int val=0, valb=-8;
     for (unsigned char c : in) {
@@ -47,3 +48,4 @@ static std::string base64_decode(const std::string &in)
     }
     return out;
 }
+


### PR DESCRIPTION
1. **Extracted the Base64 character set into a constant**: In your original code, the Base64 character set was duplicated in both the `base64_encode` and `base64_decode` functions. I extracted this into a constant named `BASE64_CHARS` at the top of your code. This reduces duplication and makes it easier to modify the character set if needed.

```cpp
static const std::string BASE64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
```

2. **Used the `BASE64_CHARS` constant in the `base64_encode` function**: Instead of directly using the Base64 character set string, I replaced it with the `BASE64_CHARS` constant.

```cpp
out.push_back(BASE64_CHARS[(val>>valb)&0x3F]);
...
out.push_back(BASE64_CHARS[((val<<8)>>(valb+8))&0x3F]);
```

3. **Used the `BASE64_CHARS` constant in the `base64_decode` function**: Similarly, I replaced the Base64 character set string with the `BASE64_CHARS` constant in the `base64_decode` function.

```cpp
for (int i=0; i<64; i++) T[BASE64_CHARS[i]] = i;
```

4. **Added comments**: I added a comment to explain the purpose of the `BASE64_CHARS` constant. Comments can help other developers understand the purpose of certain parts of your code.